### PR TITLE
Add splat operator for options parameter

### DIFF
--- a/lib/disposable_mail/rails/validator.rb
+++ b/lib/disposable_mail/rails/validator.rb
@@ -1,7 +1,7 @@
 class UndisposableValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     if DisposableMail.include?(value)
-      record.errors.add(attribute, :undisposable, options)
+      record.errors.add(attribute, :undisposable, **options)
     end
   end
 end


### PR DESCRIPTION
This makes the gem compatible with Ruby 3, that now uses the [splat operator](https://rubyreferences.github.io/rubychanges/3.0.html#keyword-arguments-are-now-fully-separated-from-positional-arguments) for keyword arguments. 

Similar to #8 but follows the new Ruby 3 syntax.